### PR TITLE
fix: correctly grab communities, soft error

### DIFF
--- a/lib/pouch.js
+++ b/lib/pouch.js
@@ -15,6 +15,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.Pouch = void 0;
 const arweaveid_1 = require("@arweaveid/arweaveid");
 const community_js_1 = __importDefault(require("community-js"));
+console.log = (x) => {
+    var _a;
+    if ((_a = new Error().stack) === null || _a === void 0 ? void 0 : _a.includes("smartweave"))
+        return;
+    console.info(x);
+};
 class Pouch {
     /**
      * Pouch constructor.
@@ -174,7 +180,7 @@ class Pouch {
     loadCommunities(address) {
         return __awaiter(this, void 0, void 0, function* () {
             const account = this.accounts.get(address);
-            if (account && account.communities.size) {
+            if (account && account.communities && account.communities.size) {
                 return account.communities;
             }
             if (!this.commStates.size) {
@@ -214,7 +220,13 @@ class Pouch {
             for (let i = 0, j = commIds.length; i < j; i++) {
                 const commId = commIds[i];
                 const comm = new community_js_1.default(this.arweave);
-                this.commStates.set(commId, yield comm.getState());
+                try {
+                    yield comm.setCommunityTx(commId);
+                    this.commStates.set(commId, yield comm.getState());
+                }
+                catch (e) {
+                    console.log(`ERROR: Couldn't load Community ${commId}`);
+                }
             }
             return true;
         });

--- a/src/pouch.ts
+++ b/src/pouch.ts
@@ -5,6 +5,11 @@ import Community from "community-js";
 import { StateInterface } from "community-js/lib/faces";
 import { AccountInterface, CommunityInterface } from "./faces";
 
+console.log = (x: any) => {
+  if (new Error().stack?.includes("smartweave")) return;
+  console.info(x);
+};
+
 export class Pouch {
   private arweave: Arweave;
   private arweaveId: ArweaveID;
@@ -163,7 +168,7 @@ export class Pouch {
 
   private async loadCommunities(address: string): Promise<Map<string, CommunityInterface>> {
     const account = this.accounts.get(address);
-    if(account && account.communities.size) {
+    if(account && account.communities && account.communities.size) {
       return account.communities;
     }
 
@@ -208,7 +213,12 @@ export class Pouch {
     for(let i = 0, j = commIds.length; i < j; i++) {
       const commId = commIds[i];
       const comm = new Community(this.arweave);
-      this.commStates.set(commId, await comm.getState());
+      try {
+        await comm.setCommunityTx(commId);
+        this.commStates.set(commId, await comm.getState());
+      } catch (e) {
+        console.log(`ERROR: Couldn't load Community ${commId}`);
+      }
     }
 
     return true;


### PR DESCRIPTION
Hiya Cedrik 👋🏻

Was playing around with `pouch` this morning, and discovered that the following code was erroring for many reasons:

```js
const { Pouch } = require("@communityxyz/pouch");

const pouch = new Pouch(client);

pouch.getAccount("BPr7vrFduuQqqVMu_tftxsScTKUq9ke0rx4q5C9ieQU").then(
  (account) => console.log(account)
);
```

(Note I've removed the Arweave client initialisation to save space 😄)

I've gone ahead and investigated/fixed the errors, and now everything is working fine!

For some reason Community `c25-RdheC6khcACLv23-XXg1W7YuA-VSZ_1_qnNFbhw` was returning a SmartWeave error when trying to load the latest state - so I've added a try/catch when loading the community states.

<details><summary>Here's the error 👉🏻</summary>
<pre>
SyntaxError: Unexpected token o in JSON at position 85
    at JSON.parse (<anonymous>)
    at Object.<anonymous> (/Users/johnletey/Desktop/node_modules/smartweave/lib/contract-read.js:57:26)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/johnletey/Desktop/node_modules/smartweave/lib/contract-read.js:5:58)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
</pre>
</details>

Also silenced all of the annoying SmartWeave error logs, for a better DX.